### PR TITLE
Fix for TinyMCE component

### DIFF
--- a/MDrivenTurnkeyComponents/EXT_Components/TinyMCE/TinyMCE.cshtml
+++ b/MDrivenTurnkeyComponents/EXT_Components/TinyMCE/TinyMCE.cshtml
@@ -1,1 +1,1 @@
-<textarea ui-tinymce ng-model='data.[ViewModelColumnName]'/>
+<textarea ui-tinymce ng-model='data.[ViewModelColumnName]'></textarea>


### PR DESCRIPTION
Fixing an issue when TinyMCE component truncates the rest of the page because of an incorrect HTML closing tag for the component's parent element.